### PR TITLE
Adds QuitWindow command which quits vim when closing last window

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -327,6 +327,7 @@ pub enum Cmd {
   GrowWindow(frame::Orientation),
   ShrinkWindow(frame::Orientation),
   CloseWindow,
+  QuitWindow,
   Quit,
   WinCmd(WinCmd),
 }

--- a/src/rim.rs
+++ b/src/rim.rs
@@ -268,6 +268,13 @@ impl Rim {
         self.resize_window(orientation, -10),
       command::Cmd::CloseWindow               =>
         self.close_window(),
+      command::Cmd::QuitWindow                => {
+        if self.windows.len() == 1 {
+          self.quit = true;
+        } else {
+          self.close_window();
+        }
+      }
       command::Cmd::Quit                      =>
         { self.quit = true; }
       command::Cmd::WinCmd(cmd)               => {
@@ -685,6 +692,16 @@ fn default_mode() -> command::Mode {
     Cmd::ShiftFocus(frame::WindowOrder::PreviousWindow));
   mode.keychain.bind(&[Key::Unicode{codepoint: 'q', mods: keymap::MOD_NONE}],
     Cmd::Quit);
+  mode.keychain.bind(&[Key::Unicode{codepoint: 'w', mods: keymap::MOD_CTRL}
+                      ,Key::Unicode{codepoint: 'q', mods: keymap::MOD_CTRL}],
+    Cmd::QuitWindow);
+  mode.keychain.bind(&[Key::Unicode{codepoint: 'w', mods: keymap::MOD_CTRL}
+                      ,Key::Unicode{codepoint: 'q', mods: keymap::MOD_NONE}],
+    Cmd::QuitWindow);
+  mode.keychain.bind(&[Key::Unicode{codepoint: ':', mods: keymap::MOD_NONE}
+                      ,Key::Unicode{codepoint: 'q', mods: keymap::MOD_NONE}
+                      ,Key::Sym{sym: KeySym::Enter, mods: keymap::MOD_NONE}],
+    Cmd::QuitWindow);
   mode.keychain.bind(&[Key::Sym{sym: KeySym::Left, mods: keymap::MOD_NONE}],
     Cmd::WinCmd(WinCmd::MoveCaret(caret::Adjustment::CharPrev)));
   mode.keychain.bind(&[Key::Sym{sym: KeySym::Right, mods: keymap::MOD_NONE}],


### PR DESCRIPTION
This functionality is relative to :q[uit] of vim

Add bindings:
:q<enter>
Ctrl+W Ctrl+Q
Ctrl+W q
